### PR TITLE
ci: use default bundler on ruby head

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 David Rabkin
+# SPDX-License-Identifier: 0BSD
+---
+name: dependency-review
+'on':
+  pull_request:
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  dependency-review:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/dependency-review-action@v5.0.0

--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -41,6 +41,7 @@ jobs:
         include:
           - os: ubuntu-24.04
             ruby: head
+            bundler: default
     name: Rake on ${{ matrix.os }} / Ruby ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
@@ -52,5 +53,6 @@ jobs:
       - uses: ruby/setup-ruby@v1.318.0
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: ${{ matrix.bundler || 'Gemfile.lock' }}
           bundler-cache: true
       - run: bundle exec rake

--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -38,9 +38,13 @@ jobs:
           - 3.2
           - 3.3
           - 3.4
+        include:
+          - os: ubuntu-24.04
+            ruby: head
     name: Rake on ${{ matrix.os }} / Ruby ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    continue-on-error: ${{ matrix.ruby == 'head' }}
     steps:
       - uses: actions/checkout@v7.0.0
         with:


### PR DESCRIPTION
The experimental ruby-head job fails with
`Bundler::CorruptBundlerInstallError`: setup-ruby installs Bundler 2.7.1
(from the Gemfile.lock `BUNDLED WITH` section), which clashes with the
4.1.0.dev Bundler specification shipped as a default gem in ruby-head
snapshots.

Sets `bundler: default` for the head matrix entry only, so the job uses
the Bundler bundled with the snapshot. Stable rubies keep the
`Gemfile.lock` behavior.

Lint results: `yamllint --strict`, `actionlint`, and `zizmor .` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated Ruby workflow configuration to support flexible Bundler settings.
  * Standardized dependency installation to use the lockfile by default, with an override for specific Ruby environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->